### PR TITLE
Add alt text for book images

### DIFF
--- a/book1.html
+++ b/book1.html
@@ -43,7 +43,7 @@
             <div class="container">
                 <div class="book-full-container">
                     <div class="book-full-cover">
-                        <img src="./images/stolen_freedom_cover.jpg">
+                        <img src="./images/stolen_freedom_cover.jpg" alt="Stolen Freedom cover">
                     </div>
                     <div class="book-full-details">
                         <h2>Stolen Freedom</h2>

--- a/book2.html
+++ b/book2.html
@@ -43,7 +43,7 @@
             <div class="container">
                 <div class="book-full-container">
                     <div class="book-full-cover">
-                        <img src="./images/wings_of_freedom_cover.jpg">
+                        <img src="./images/wings_of_freedom_cover.jpg" alt="Wings of Freedom cover">
                     </div>
                     <div class="book-full-details">
                         <h2>Wings of Freedom</h2>

--- a/book3.html
+++ b/book3.html
@@ -43,7 +43,7 @@
             <div class="container">
                 <div class="book-full-container">
                     <div class="book-full-cover">
-                        <img src="./images/book3_cover.png">
+                        <img src="./images/book3_cover.png" alt="The Jackrabbit Emerges cover">
                     </div>
                     <div class="book-full-details">
                         <h2>The Jackrabbit Emerges</h2>

--- a/book4.html
+++ b/book4.html
@@ -42,7 +42,7 @@
 <div class="container">
 <div class="book-full-container">
 <div class="book-full-cover">
-<img src="./images/coming_of_age_cover.png"</img>
+<img src="./images/coming_of_age_cover.png" alt="Coming of Age cover">
 </div>
 <div class="book-full-details">
 <h2>Coming of Age</h2>

--- a/books.html
+++ b/books.html
@@ -44,7 +44,7 @@
                 <div class="books-list">
                     <div class="book-item">
                         <div class="book-cover">
-                            <img src="./images/stolen_freedom_cover.jpg"</img>
+                            <img src="./images/stolen_freedom_cover.jpg" alt="Stolen Freedom cover">
                         </div>
                         <div class="book-details">
                             <h2>Stolen Freedom</h2>
@@ -81,7 +81,7 @@
                     </div>
                     <div class="book-item">
                         <div class="book-cover">
-                            <img src="./images/wings_of_freedom_cover.jpg">
+                            <img src="./images/wings_of_freedom_cover.jpg" alt="Wings of Freedom cover">
                         </div>
                         <div class="book-details">
                             <h2>Wings of Freedom</h2>
@@ -120,7 +120,7 @@
 
                     <div class="book-item">
                         <div class="book-cover">
-                            <img src="./images/book3_cover.png">
+                            <img src="./images/book3_cover.png" alt="The Jackrabbit Emerges cover">
                         </div>
                         <div class="book-details">
                             <h2>The Jackrabbit Emerges</h2>
@@ -166,7 +166,7 @@
 
                     <div class="book-item">
                         <div class="book-cover">
-                            <img src="./images/coming_of_age_cover.png"</img>
+                            <img src="./images/coming_of_age_cover.png" alt="Coming of Age cover">
                         </div>
                         <div class="book-details">
                             <h2>Coming of Age</h2>

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
                     <div class="book-card">
                         <div class="book-cover">
                             <div class="placeholder-cover book1">
-                                <img src="./images/stolen_freedom_cover.jpg">
+                                <img src="./images/stolen_freedom_cover.jpg" alt="Stolen Freedom cover">
                             </div>
                         </div>
                         <div class="book-info">
@@ -66,7 +66,7 @@
                     <div class="book-card">
                         <div class="book-cover">
                             <div class="placeholder-cover book2">
-                                <img src="./images/wings_of_freedom_cover.jpg">
+                                <img src="./images/wings_of_freedom_cover.jpg" alt="Wings of Freedom cover">
                             </div>
                         </div>
                         <div class="book-info">
@@ -80,7 +80,7 @@
                     <div class="book-card">
                         <div class="book-cover">
                             <div class="placeholder-cover book3">
-                                <img src="./images/book3_cover.png">
+                                <img src="./images/book3_cover.png" alt="The Jackrabbit Emerges cover">
                             </div>
                         </div>
                         <div class="book-info">
@@ -94,7 +94,7 @@
                     <div class="book-card">
                         <div class="book-cover">
                             <div class="placeholder-cover book3">
-                                <img src="./images/coming_of_age_cover.png">
+                                <img src="./images/coming_of_age_cover.png" alt="Coming of Age cover">
                             </div>
                         </div>
                         <div class="book-info">


### PR DESCRIPTION
## Summary
- add alt attributes for book cover images in `index.html`
- add alt attributes and fix `<img>` tags in `books.html`
- add alt attributes for images in individual book pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840a0d82e60832f87f1ecefde28cc11