### PR TITLE
Add favicon links to all HTML pages

### DIFF
--- a/Book_1_Prologue.html
+++ b/Book_1_Prologue.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="Stolen Freedom prologue, Jackrabbit, science fiction, Tony Marks, book excerpt">
     <title>Prologue - Stolen Freedom - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/Gilbert_s Quest.html
+++ b/Gilbert_s Quest.html
@@ -9,6 +9,9 @@
 <meta name="keywords" content="Gilbert's Quest, interactive fiction, Jackrabbit, Twine game, science fiction, Tony Marks" />
 <meta name="application-name" content="SugarCube" />
 <meta name="version" content="2.37.3" />
+<link rel="icon" href="/favicon.ico" />
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png" />
+<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 <!--
 
 SugarCube (v2.37.3): A free (gratis and libre) story format.

--- a/book1.html
+++ b/book1.html
@@ -19,6 +19,9 @@
     <meta name="twitter:description" content="In a brutal mining colony, young Jack discovers a damaged ship and a forbidden AI named Aggie. Together they plan an escape that will change everything.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/Stolen_Freedom_base.jpg">
     <title>Stolen Freedom - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/book2.html
+++ b/book2.html
@@ -19,6 +19,9 @@
     <meta name="twitter:description" content="Jack and Aggie navigate a universe of corporate greed, developing piloting skills and forming unexpected alliances while protecting Aggie's dangerous secret.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/wings_of_freedom_cover.jpg">
     <title>Wings of Freedom - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/book3.html
+++ b/book3.html
@@ -19,6 +19,9 @@
     <meta name="twitter:description" content="In a fractured Dyson Array, Jack becomes a symbol of hope for stranded survivors. As corporations hunt for the mysterious ship, a legend is born.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/the_jackrabbit_emerges_base_front.jpg">
     <title>The Jackrabbit Emerges - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/book4.html
+++ b/book4.html
@@ -20,6 +20,9 @@
 <meta name="twitter:description" content="Jack infiltrates the corporate system as a courier, rising through ranks while Aggie makes discoveries that could change everything."/>
 <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/coming_of_age_cover.jpg"/>
 <title>Coming of Age - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/book5.html
+++ b/book5.html
@@ -20,6 +20,9 @@
 <meta name="twitter:description" content="The saga's conclusion. Jack and multiple Aggies join the resistance to challenge corporate dominance. The Jackrabbit legend becomes a galaxy-wide revolution."/>
 <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/Stolen_Freedom_base.jpg"/>
 <title>The Proliferation - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/books.html
+++ b/books.html
@@ -19,6 +19,9 @@
     <meta name="twitter:description" content="Explore all five books in The Jackrabbit series. From a boy's escape from a mining colony to a galaxy-wide revolution.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/Stolen_Freedom_base.jpg">
     <title>Books - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/character1.html
+++ b/character1.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Jack Abbott, Jackrabbit, protagonist, science fiction character, Tony Marks"/>
 <title>Jack Abbott - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character10.html
+++ b/character10.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Foreman Oswald, Ozzy, Jackrabbit, shipyard, science fiction character, Tony Marks"/>
 <title>Foreman Oswald (Ozzy) - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character11.html
+++ b/character11.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Burke, Jackrabbit, engineer, science fiction character, Tony Marks"/>
 <title>Burke - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character12.html
+++ b/character12.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Chas Drayton, Jackrabbit, antagonist, science fiction character, Tony Marks"/>
 <title>Chas Drayton - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character13.html
+++ b/character13.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Veronica Bennett, Jackrabbit, pilot training, science fiction character, Tony Marks"/>
 <title>Veronica Bennett - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character14.html
+++ b/character14.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="Commodore Razer, Jackrabbit, mercenary, antagonist, science fiction character, Tony Marks">
     <title>Commodore Razer - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/character15.html
+++ b/character15.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Administrator Chen, Fragment Alpha, Jackrabbit, Dyson Array, science fiction character, Tony Marks"/>
 <title>Administrator Chen - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character16.html
+++ b/character16.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="General Singh, Fragment Alpha, Jackrabbit, military commander, science fiction character, Tony Marks"/>
 <title>General Singh - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character17.html
+++ b/character17.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Commander Reeves, Lucy Reeves, Jackrabbit, security chief, science fiction character, Tony Marks"/>
 <title>Commander Reeves - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character18.html
+++ b/character18.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Dr. Eli Vega, Project Starling, Jackrabbit, scientist, science fiction character, Tony Marks"/>
 <title>Dr. Eli Vega - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character19.html
+++ b/character19.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Commander Reika, raiders, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Commander Reika - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character2.html
+++ b/character2.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Aggie, AGI, Artificial General Intelligence, Jackrabbit, deuteragonist, Tony Marks"/>
 <title>Aggie - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character20.html
+++ b/character20.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Krell, raiders, antagonist, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Krell - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character21.html
+++ b/character21.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Steve Harman, Blue Spanner, Fragment Omicron, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Steve Harman - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character22.html
+++ b/character22.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Thomas, Marcus, Fragment Lambda, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Thomas &amp; Marcus - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character23.html
+++ b/character23.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Mr. Grey, OmniFab, corporate antagonist, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Mr. Grey - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character24.html
+++ b/character24.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Director Vera Santos, OmniFab, Intelligence, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Director Vera Santos - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character25.html
+++ b/character25.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Mr. Mercury, AetherLink, corporate antagonist, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Mr. Mercury - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character26.html
+++ b/character26.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="Ms. Blackwood, QuantumGrid, corporate antagonist, Jackrabbit, science fiction character, Tony Marks">
     <title>Ms. Blackwood - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/character27.html
+++ b/character27.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Amondi Nkosi, AetherLink, analyst, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Amondi Nkosi - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character28.html
+++ b/character28.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Decker, raiders, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Decker - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character29.html
+++ b/character29.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Daniel, maintenance worker, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Daniel - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character3.html
+++ b/character3.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Victor Drayton, Jackrabbit, antagonist, science fiction character, Tony Marks"/>
 <title>Victor Drayton - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character30.html
+++ b/character30.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Frank Kowalski, Aletheion, mentor, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Frank Kowalski - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character31.html
+++ b/character31.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Amanda Kowalski, CyberNexus, researcher, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Amanda Kowalski - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character32.html
+++ b/character32.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Eleanor Kowalski, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Eleanor Kowalski - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character33.html
+++ b/character33.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Katherine Keller, Aletheion, corporate antagonist, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Katherine Keller - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character34.html
+++ b/character34.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Director Halsey, Aletheion, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Director Halsey - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character4.html
+++ b/character4.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Albert Abbott, Dorothy Abbott, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Albert &amp; Dorothy Abbott - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character5.html
+++ b/character5.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Dock Officer Bartram, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Dock Officer Bartram - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character6.html
+++ b/character6.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Brinn, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Brinn - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character7.html
+++ b/character7.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Dr. Agatha Locke, AGI creator, Jackrabbit, science fiction character, Tony Marks"/>
 <title>Dr. Agatha Locke - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character8.html
+++ b/character8.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Gilbert, Jackrabbit, resistance, science fiction character, Tony Marks"/>
 <title>Gilbert - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/character9.html
+++ b/character9.html
@@ -8,6 +8,9 @@
 <meta name="author" content="Tony Marks"/>
 <meta name="keywords" content="Captain Marcus Hale, Jackrabbit, pilot instructor, science fiction character, Tony Marks"/>
 <title>Captain Marcus Hale - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
 <link href="css/styles.css" rel="stylesheet"/>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>

--- a/characters.html
+++ b/characters.html
@@ -19,6 +19,9 @@
     <meta name="twitter:description" content="Meet the characters of The Jackrabbit series - from Jack Abbott and the forbidden AGI Aggie, to corporate villains and resistance fighters.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/Stolen_Freedom_base.jpg">
     <title>Characters - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/contact.html
+++ b/contact.html
@@ -18,6 +18,9 @@
     <meta name="twitter:description" content="Contact Tony Marks, author of The Jackrabbit series. Share your thoughts or ask questions about the books.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/Stolen_Freedom_base.jpg">
     <title>Contact the Author - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/AG.html
+++ b/encyclopaedia/AG.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="artificial gravity, Jackrabbit, science fiction, space technology, space opera worldbuilding">
     <title>Artificial Gravity - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/AGI.html
+++ b/encyclopaedia/AGI.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="AGI, Artificial General Intelligence, Jackrabbit, science fiction, AI consciousness, Aggie">
     <title>Artificial General Intelligence (AGI) - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/AI.html
+++ b/encyclopaedia/AI.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="AI, Artificial Intelligence, Jackrabbit, science fiction, automation, corporate technology">
     <title>Artificial Intelligence (AI) - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/AtmosphericSystems.html
+++ b/encyclopaedia/AtmosphericSystems.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="atmospheric systems, life support, Jackrabbit, science fiction, space technology, space opera">
     <title>Atmospheric Management Systems - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/Governance.html
+++ b/encyclopaedia/Governance.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="corporate governance, dystopian, corporate rule, Jackrabbit, science fiction, megacorporations">
     <title>Corporate Governance - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/SnapMesh.html
+++ b/encyclopaedia/SnapMesh.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="SnapMesh, FTL communication, Jackrabbit, science fiction, interstellar network, space opera technology">
     <title>SnapMesh - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/SnapSpace.html
+++ b/encyclopaedia/SnapSpace.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="SnapSpace, FTL travel, faster than light, Jackrabbit, science fiction, space opera technology">
     <title>SnapSpace Travel - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/Suits.html
+++ b/encyclopaedia/Suits.html
@@ -7,6 +7,9 @@
     <meta name="author" content="Tony Marks">
     <meta name="keywords" content="space suits, hazardous environment, Jackrabbit, science fiction, space technology, protective equipment">
     <title>Hazardous Environment Suits - The Jackrabbit Encyclopaedia</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/encyclopaedia/encyclopaedia.html
+++ b/encyclopaedia/encyclopaedia.html
@@ -19,6 +19,9 @@
     <meta name="twitter:description" content="Explore the technologies of the 23rd century - AGI, SnapSpace travel, artificial gravity, and more. Your guide to The Jackrabbit universe.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/Stolen_Freedom_base.jpg">
     <title>Encyclopaedia - The Jackrabbit</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
     <meta name="twitter:description" content="In a universe ruled by corporations, one boy and a forbidden AI forge an unlikely alliance. A dystopian space opera about freedom, survival, and revolution.">
     <meta name="twitter:image" content="https://www.jackrabbit-series.com/images/Stolen_Freedom_base.jpg">
     <title>The Jackrabbit - Science Fiction Book Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="stylesheet" href="css/styles.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/misc/absolute_zero.html
+++ b/misc/absolute_zero.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Temporal Singularity of Absolute Zero</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <style>
         * {
             margin: 0;


### PR DESCRIPTION
Added three favicon link tags to the <head> section of all 55 HTML pages:
- Standard favicon.ico for browser support
- 32x32 PNG favicon for modern browsers
- Apple touch icon for iOS devices

This improves the site's branding and user experience across all pages and devices.

https://claude.ai/code/session_013ENjDcHYq91kT41Pe1o2sC