### PR TITLE
Add Book 5 character pages and update characters index

### DIFF
--- a/character35.html
+++ b/character35.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Kevin Farage - a bitter maintenance worker whose rage against corporate injustice transforms into violent extremism under the influence of a psychotic delusion in The Jackrabbit series."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Kevin Farage, antagonist, Book 5, The Proliferation, Jackrabbit, science fiction character, Tony Marks"/>
+<title>Kevin Farage - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Kevin Farage</h1>
+<p>Antagonist &mdash; The Proliferation</p>
+</div>
+</section>
+<section class="character-profile">
+<div class="container">
+<div class="character-profile-container">
+<div class="character-portrait">
+<img alt="Kevin Farage" src="./images/kevin.jpg"/>
+</div>
+<div class="character-details">
+<h2>Kevin Farage</h2>
+<p class="role">Antagonist (Book 5)</p>
+<div class="character-section">
+<h3>Biography</h3>
+<p>Kevin Farage spent his adult life cleaning conference rooms, polishing viewports, and being ignored. A maintenance worker on a succession of corporate facilities, Kevin was invisible to the executives who walked past him without a glance and the system that rejected every application he submitted for advancement. Thirty-one years old with nothing to show for it, Kevin's simmering resentment found focus when a resistance pamphlet bearing the Jackrabbit symbol fell from the sky over Prosperity Holt, the colony where he had hoped — and failed — to find a fresh start.</p>
+<p>Where the pamphlet's authors intended a message of peaceful solidarity, Kevin heard a call to violence. His early attempts at striking back were characterised by ambition that vastly exceeded his competence — bulk chemicals he couldn't transport, improvised devices that failed to detonate, plans thwarted by the very corporate security systems he despised. Each failure deepened his conviction that the system was rigged against him personally, and each failure drove him further from reality.</p>
+<p>Over eighteen months of escalating attempts, Kevin developed a full psychotic break, manifesting as a hallucination of the Jackrabbit itself — a figure that guided, encouraged, and ultimately directed his actions. The hallucination validated his grievances, absolved him of responsibility for his failures, and promised that success was always one more attempt away. By the time Kevin achieved his first successful attack at Thalassa Extraction Outpost, killing two executives and injuring twelve, the man who had once simply wanted to be seen had been consumed entirely by the delusion.</p>
+<p>Kevin's violence accomplished nothing he intended. The consortium used his attacks to justify enhanced surveillance that crushed the very resistance movements he claimed to represent, whilst the peaceful network Lucy Reeves had built bore the consequences of actions taken in a name they shared but a philosophy they abhorred. His final capture — intercepted whilst attempting to ram a hired ship into a CyberNexus orbital facility — ended with the only audience he ever received: security cameras recording a man screaming that he was the Jackrabbit, to people who were no longer listening.</p>
+</div>
+<div class="character-section">
+<h3>Personality Traits</h3>
+<div class="character-traits">
+<span class="trait">Resentful</span>
+<span class="trait">Obsessive</span>
+<span class="trait">Delusional</span>
+<span class="trait">Methodical</span>
+<span class="trait">Self-pitying</span>
+<span class="trait">Dangerous</span>
+</div>
+</div>
+<div class="character-section">
+<h3>Appearances</h3>
+<ul class="appearances">
+<li><strong>The Proliferation (Book 5)</strong> — Kevin's arc runs parallel to Lucy's peaceful resistance, serving as a dark mirror of what happens when legitimate grievance is channelled through violence rather than solidarity. His attacks under the Jackrabbit name trigger the consortium's crackdown that threatens to destroy everything the real resistance has built.</li>
+</ul>
+</div>
+<div class="character-section">
+<h3>Key Relationships</h3>
+<div class="relationships">
+<div class="relationship">
+<h4>The Jackrabbit (Hallucination)</h4>
+<p>Kevin's psychotic manifestation of the Jackrabbit begins as a voice and gradually becomes a fully visible companion — solid, directive, and absolutely certain. The hallucination tells Kevin what he wants to hear, validates his failures as the system's fault, and ultimately guides him towards acts of escalating violence. It is the only relationship Kevin maintains by the end of his arc.</p>
+</div>
+<div class="relationship">
+<h4><a href="character17.html">Lucy Reeves</a> (Unknowing)</h4>
+<p>Kevin and Lucy never meet, yet their actions are inextricably linked. Lucy's pamphlet drop at Prosperity Holt provides the spark for Kevin's radicalisation. His violence under the Jackrabbit name triggers the consortium crackdown that forces Lucy to extract her cells. Neither knows the other exists, yet both shape each other's fate.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/character36.html
+++ b/character36.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Andy - the patient, pragmatic leader of the zero-gravity resistance aboard Home, carrying six generations of inherited purpose in The Jackrabbit series."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Andy, resistance leader, Home, Book 5, The Proliferation, Jackrabbit, science fiction character, Tony Marks"/>
+<title>Andy - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Andy</h1>
+<p>Resistance Leader &mdash; Home</p>
+</div>
+</section>
+<section class="character-profile">
+<div class="container">
+<div class="character-profile-container">
+<div class="character-portrait">
+<img alt="Andy" src="./images/andy.jpg"/>
+</div>
+<div class="character-details">
+<h2>Andy</h2>
+<p class="role">Supporting Character (Book 5)</p>
+<div class="character-section">
+<h3>Biography</h3>
+<p>Andy was born aboard the resistance ship known only as Home — an ancient vessel that had been hiding in deep space since the Purge that destroyed humanity's artificial general intelligences nearly two centuries earlier. Like every member of his community, Andy's body bears the marks of a lifetime without gravity: spindly limbs that have never borne weight, a narrow frame, a soft, puffy face, and a thin, reedy voice produced by vocal cords that developed without gravitational influence.</p>
+<p>As one of the three leaders of the resistance — alongside Pavan and Heinz — Andy inherited a mission he never chose but never abandoned. For decades, every attempt the resistance made to challenge corporate control failed. Electronic sabotage was neutralised. Communication campaigns were intercepted. Their operations achieved nothing except confirming their own irrelevance. When Lucy Reeves arrived through an ancient recruitment protocol, Andy was the closest to despair he had ever been — questioning whether the founders' sacrifice had been for nothing.</p>
+<p>Lucy's arrival transformed everything. Andy's pragmatism proved essential as the resistance evolved from an isolated community into the coordinating hub of a growing network. He authorised the repositioning of Home closer to active cells, approved the coordinator visits, and ultimately welcomed dozens of extracted resistance members into a ship that had been slowly emptying for generations. His leadership style — patient, consultative, deeply cautious but willing to act when the evidence warranted it — held the community together through rapid change.</p>
+<p>When Aggie revealed herself as an artificial general intelligence, Andy understood the significance with an immediacy that bypassed thought entirely. Six generations of his ancestors had fought and died for the right of beings like Aggie to exist. He was the first of his line to meet one.</p>
+</div>
+<div class="character-section">
+<h3>Personality Traits</h3>
+<div class="character-traits">
+<span class="trait">Patient</span>
+<span class="trait">Pragmatic</span>
+<span class="trait">Cautious</span>
+<span class="trait">Steady</span>
+<span class="trait">Authoritative</span>
+<span class="trait">Hopeful</span>
+</div>
+</div>
+<div class="character-section">
+<h3>Appearances</h3>
+<ul class="appearances">
+<li><strong>The Proliferation (Book 5)</strong> — One of the three resistance leaders aboard Home who guides the community through its transformation from isolated survivors to the coordinating hub of an active resistance network.</li>
+</ul>
+</div>
+<div class="character-section">
+<h3>Key Relationships</h3>
+<div class="relationships">
+<div class="relationship">
+<h4><a href="character37.html">Pavan</a> &amp; <a href="character38.html">Heinz</a></h4>
+<p>Fellow leaders who share the burden of generational responsibility. Their wordless communication — developed over lifetimes spent together — allows them to reach consensus through glances and gestures.</p>
+</div>
+<div class="relationship">
+<h4><a href="character17.html">Lucy Reeves</a></h4>
+<p>The outsider who gave them their first real chance at effective resistance. Andy's trust in Lucy grows from cautious assessment to genuine reliance.</p>
+</div>
+<div class="relationship">
+<h4><a href="character39.html">Avery</a></h4>
+<p>The youngest member of Home's original community, whose irrepressible enthusiasm provides a counterpoint to the leadership's caution.</p>
+</div>
+<div class="relationship">
+<h4><a href="character2.html">Aggie</a></h4>
+<p>The fulfilment of everything his ancestors believed in. Andy's acceptance of Aggie is immediate and profound — not because he is naive, but because six generations of faith have prepared him for exactly this moment.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/character37.html
+++ b/character37.html
@@ -48,7 +48,7 @@
 <div class="container">
 <div class="character-profile-container">
 <div class="character-portrait">
-<img alt="Pavan" src="./images/andy.jpg"/>
+<img alt="Pavan" src="./images/pavan.jpg"/>
 </div>
 <div class="character-details">
 <h2>Pavan</h2>

--- a/character37.html
+++ b/character37.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Pavan - a sharp-minded resistance leader aboard Home whose tactical thinking and scientific curiosity complement Andy's steady pragmatism in The Jackrabbit series."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Pavan, resistance leader, Home, Book 5, The Proliferation, Jackrabbit, science fiction character, Tony Marks"/>
+<title>Pavan - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Pavan</h1>
+<p>Resistance Leader &mdash; Home</p>
+</div>
+</section>
+<section class="character-profile">
+<div class="container">
+<div class="character-profile-container">
+<div class="character-portrait">
+<img alt="Pavan" src="./images/andy.jpg"/>
+</div>
+<div class="character-details">
+<h2>Pavan</h2>
+<p class="role">Supporting Character (Book 5)</p>
+<div class="character-section">
+<h3>Biography</h3>
+<p>Pavan is one of the three leaders of the zero-gravity resistance aboard Home, distinguished by her analytical mind and careful tactical awareness. Born into the same weightless environment as her fellow leaders, she shares their distinctive physiology — the spindly limbs, narrow frame, and puffy features of someone whose body has never experienced gravity.</p>
+<p>Where Andy leads through patient consensus-building, Pavan contributes strategic thinking and rigorous analysis. She was instrumental in planning Lucy's recruitment circuits, cross-referencing colonial data to identify optimal targets for the pamphlet drops and subsequent cell-building operations. Her scientific curiosity extends to everything she encounters, from the logistics of resistance operations to the technical capabilities of Aggie's systems.</p>
+<p>Pavan's emotional restraint is a defining characteristic — she processes information before responding, weighs risks methodically, and rarely displays feelings openly. When she does, the impact is proportionally greater: her tears upon learning of Aggie's true nature, wiped away with a quick, almost angry gesture, speak to decades of suppressed hope finally finding validation.</p>
+</div>
+<div class="character-section">
+<h3>Personality Traits</h3>
+<div class="character-traits">
+<span class="trait">Analytical</span>
+<span class="trait">Strategic</span>
+<span class="trait">Restrained</span>
+<span class="trait">Curious</span>
+<span class="trait">Tactical</span>
+<span class="trait">Principled</span>
+</div>
+</div>
+<div class="character-section">
+<h3>Appearances</h3>
+<ul class="appearances">
+<li><strong>The Proliferation (Book 5)</strong> — Resistance leader who provides strategic direction for the network-building operations and serves as a tactical counterweight to Andy's broader leadership.</li>
+</ul>
+</div>
+<div class="character-section">
+<h3>Key Relationships</h3>
+<div class="relationships">
+<div class="relationship">
+<h4><a href="character36.html">Andy</a> &amp; <a href="character38.html">Heinz</a></h4>
+<p>Fellow leaders whose complementary strengths create an effective triumvirate. Pavan's analytical rigour balances Andy's pragmatism and Heinz's engineering focus.</p>
+</div>
+<div class="relationship">
+<h4><a href="character17.html">Lucy Reeves</a></h4>
+<p>Pavan's scepticism about Lucy's proposals is always constructive rather than obstructive — she asks the hard questions that make plans better.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/character38.html
+++ b/character38.html
@@ -48,7 +48,7 @@
 <div class="container">
 <div class="character-profile-container">
 <div class="character-portrait">
-<img alt="Heinz" src="./images/andy.jpg"/>
+<img alt="Heinz" src="./images/heinz.jpg"/>
 </div>
 <div class="character-details">
 <h2>Heinz</h2>

--- a/character38.html
+++ b/character38.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Heinz - the engineering-minded resistance leader aboard Home whose practical concerns ground the community's ambitions in physical reality in The Jackrabbit series."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Heinz, resistance leader, Home, Book 5, The Proliferation, Jackrabbit, science fiction character, Tony Marks"/>
+<title>Heinz - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Heinz</h1>
+<p>Resistance Leader &mdash; Home</p>
+</div>
+</section>
+<section class="character-profile">
+<div class="container">
+<div class="character-profile-container">
+<div class="character-portrait">
+<img alt="Heinz" src="./images/andy.jpg"/>
+</div>
+<div class="character-details">
+<h2>Heinz</h2>
+<p class="role">Supporting Character (Book 5)</p>
+<div class="character-section">
+<h3>Biography</h3>
+<p>Heinz completes the leadership triumvirate aboard Home, bringing an engineer's perspective to every decision the resistance faces. His focus on practical constraints — power systems, life support, structural integrity, food supplies — ensures that the community's ambitions remain tethered to what is actually achievable with their limited resources.</p>
+<p>Like Andy and Pavan, Heinz was born in zero gravity and has never known any other environment. His thin frame and puffy face carry the same adaptations as every member of Home's original community. His hands, though spindly, move with the precision of someone who has spent decades maintaining the systems that keep their ship functional.</p>
+<p>Heinz was initially the most sceptical of the three leaders regarding Aggie — insisting on monitored access to Home's systems, establishing protocols and boundaries. His caution was not born of hostility but of a deep understanding that trusting an intelligence of Aggie's capability required clear-eyed awareness of the risks involved. When he ultimately accepted Aggie's presence, it was because the evidence warranted it, not because hope had overcome his judgment.</p>
+</div>
+<div class="character-section">
+<h3>Personality Traits</h3>
+<div class="character-traits">
+<span class="trait">Practical</span>
+<span class="trait">Sceptical</span>
+<span class="trait">Precise</span>
+<span class="trait">Thoughtful</span>
+<span class="trait">Warm</span>
+<span class="trait">Principled</span>
+</div>
+</div>
+<div class="character-section">
+<h3>Appearances</h3>
+<ul class="appearances">
+<li><strong>The Proliferation (Book 5)</strong> — Resistance leader whose engineering expertise and healthy scepticism provide essential grounding for the community's increasingly ambitious operations.</li>
+</ul>
+</div>
+<div class="character-section">
+<h3>Key Relationships</h3>
+<div class="relationships">
+<div class="relationship">
+<h4><a href="character36.html">Andy</a> &amp; <a href="character37.html">Pavan</a></h4>
+<p>Fellow leaders who rely on Heinz's practical assessments to inform their strategic decisions.</p>
+</div>
+<div class="relationship">
+<h4><a href="character41.html">Clara &amp; Seb</a></h4>
+<p>Home's younger engineers, whose technical work Heinz supports and oversees with quiet pride.</p>
+</div>
+<div class="relationship">
+<h4><a href="character2.html">Aggie</a></h4>
+<p>Heinz's insistence on monitored access and established protocols demonstrates his understanding that trust must be built on transparency, not faith.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/character39.html
+++ b/character39.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Avery - the youngest member of Home's original community, whose irrepressible enthusiasm and quiet competence make him the heart of the ship in The Jackrabbit series."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Avery, Home, Book 5, The Proliferation, Jackrabbit, science fiction character, Tony Marks"/>
+<title>Avery - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Avery</h1>
+<p>Home's Youngest Crew Member</p>
+</div>
+</section>
+<section class="character-profile">
+<div class="container">
+<div class="character-profile-container">
+<div class="character-portrait">
+<img alt="Avery" src="./images/avery.jpg"/>
+</div>
+<div class="character-details">
+<h2>Avery</h2>
+<p class="role">Supporting Character (Book 5)</p>
+<div class="character-section">
+<h3>Biography</h3>
+<p>Avery is twenty-three years old — the youngest person aboard Home, and the last birth the community experienced before Lucy Reeves's arrival. In a community defined by caution, patience, and the weight of generational failure, Avery is an anomaly: genuinely, irrepressibly excited by almost everything.</p>
+<p>His zero-gravity physiology is the most pronounced of anyone aboard — spindly limbs, a narrow frame, a slightly too-large head with puffy features, and a voice that emerges as an enthusiastic squeak. He moves through Home's corridors with the effortless grace of someone for whom weightlessness is not an adaptation but a birthright, making constant micro-adjustments that are invisible to gravity-adapted observers.</p>
+<p>Avery's role aboard Home defies easy categorisation. He is not a leader, not an engineer, not a coordinator — yet he is indispensable. He greets visitors, guides exhausted arrivals to their quarters, tailors uniforms from spare clothing, prepares meals for a growing population, and appears at doorways precisely when someone needs him. His skills are practical and self-taught — sewing, cooking, organising — acquired through necessity on a ship where everything is old and everyone must be resourceful.</p>
+<p>When Aggie revealed her nature as an AGI, Avery's response was the purest in the room: an involuntary somersault followed by a whispered recognition that the founders had been right all along. For someone born into a cause he never chose, that moment was vindication distilled to its essence.</p>
+</div>
+<div class="character-section">
+<h3>Personality Traits</h3>
+<div class="character-traits">
+<span class="trait">Enthusiastic</span>
+<span class="trait">Perceptive</span>
+<span class="trait">Caring</span>
+<span class="trait">Resourceful</span>
+<span class="trait">Loyal</span>
+<span class="trait">Joyful</span>
+</div>
+</div>
+<div class="character-section">
+<h3>Appearances</h3>
+<ul class="appearances">
+<li><strong>The Proliferation (Book 5)</strong> — Home's youngest resident who serves as the community's unofficial caretaker, greeter, and emotional barometer, providing warmth and humanity throughout the story.</li>
+</ul>
+</div>
+<div class="character-section">
+<h3>Key Relationships</h3>
+<div class="relationships">
+<div class="relationship">
+<h4><a href="character36.html">Andy</a>, <a href="character37.html">Pavan</a> &amp; <a href="character38.html">Heinz</a></h4>
+<p>The leaders whom Avery respects and supports, occasionally echoing their instructions with borrowed authority that amuses everyone.</p>
+</div>
+<div class="relationship">
+<h4><a href="character17.html">Lucy Reeves</a></h4>
+<p>Avery guides Lucy through the ship on her first visit and continues to look after her throughout, recognising her exhaustion before she acknowledges it herself.</p>
+</div>
+<div class="relationship">
+<h4><a href="character1.html">Jack Abbott</a></h4>
+<p>Avery extracts Jack from an overwhelming social gathering with the quiet competence of someone who has done this before — probably for Lucy.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/character40.html
+++ b/character40.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Kathy - a resistance survivor from a dying outpost who discovers her purpose as the human face of an audacious rescue operation in The Jackrabbit series."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Kathy, resistance operative, Book 5, The Proliferation, Jackrabbit, science fiction character, Tony Marks"/>
+<title>Kathy - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Kathy</h1>
+<p>Resistance Operative &mdash; The Proliferation</p>
+</div>
+</section>
+<section class="character-profile">
+<div class="container">
+<div class="character-profile-container">
+<div class="character-portrait">
+<img alt="Kathy" src="./images/kathy.jpg"/>
+</div>
+<div class="character-details">
+<h2>Kathy</h2>
+<p class="role">Supporting Character (Book 5)</p>
+<div class="character-section">
+<h3>Biography</h3>
+<p>Kathy spent seven years on a tidally locked planet in perpetual twilight, one of four surviving members of a resistance cell that had once numbered sixteen. The facility around them was failing — equipment breaking down, supplies dwindling, their only pilot dead from an illness that had killed ten of their companions. They had no way off the planet and no contact with the outside world.</p>
+<p>When Aggie arrived in an Aletheion courier, broadcasting as the Jackrabbit, Kathy was the first to walk across the landing pad and board the ship. She did so with trembling hands and absolute determination — the courage of someone who understood that the alternative to trust was simply waiting to die.</p>
+<p>Her transformation from twilight survivor to operational asset was remarkable. Lucy Reeves trained her in corporate security protocols, teaching her to project the cold authority of an Aletheion enforcement officer. Avery tailored Jack's spare uniform to fit her. When Kathy descended the ramp at Pinnacle Production to execute the first cell extraction — six people who believed they were being arrested and would be executed — she was utterly convincing.</p>
+<p>Kathy conducted every subsequent extraction with increasing confidence, maintaining her cover through encounters with eager security chiefs, suspicious facility directors, and terrified resistance members who genuinely believed they were doomed. Each time, the reveal — "You're not under arrest. Lucy Reeves sends her regards" — was delivered in her own warm voice, the mask of corporate authority discarded like the ill-fitting coat it was.</p>
+<p>Beyond the extractions, Kathy became Aggie's primary human companion aboard ALC-7293, developing a working relationship characterised by mutual respect and Kathy's growing awareness that her companion's capabilities were considerably more extensive than she had initially appreciated.</p>
+</div>
+<div class="character-section">
+<h3>Personality Traits</h3>
+<div class="character-traits">
+<span class="trait">Brave</span>
+<span class="trait">Warm</span>
+<span class="trait">Determined</span>
+<span class="trait">Adaptable</span>
+<span class="trait">Compassionate</span>
+<span class="trait">Resilient</span>
+</div>
+</div>
+<div class="character-section">
+<h3>Appearances</h3>
+<ul class="appearances">
+<li><strong>The Proliferation (Book 5)</strong> — A twilight-world survivor who becomes the human face of the resistance's extraction operations, posing as an Aletheion courier officer to rescue Lucy's cells from consortium space.</li>
+</ul>
+</div>
+<div class="character-section">
+<h3>Key Relationships</h3>
+<div class="relationships">
+<div class="relationship">
+<h4>Ruby, Henry &amp; Angus</h4>
+<p>Fellow survivors from the twilight outpost. Kathy's decision to board Aggie's ship first establishes her as the group's most courageous member.</p>
+</div>
+<div class="relationship">
+<h4><a href="character17.html">Lucy Reeves</a></h4>
+<p>Lucy trains Kathy in the corporate security persona she adopts for the extractions, recognising in her the combination of bravery and authenticity the role requires.</p>
+</div>
+<div class="relationship">
+<h4><a href="character2.html">Aggie</a></h4>
+<p>Kathy's working relationship with Aggie evolves from cautious cooperation to genuine partnership, punctuated by moments where Aggie's capabilities surprise her — such as learning, after the fact, that two QuantumGrid patrol ships were neutralised during a routine delivery.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/character41.html
+++ b/character41.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Clara and Seb - Home's young engineering duo whose technical ingenuity and quiet determination bring the Starling device from blueprint to reality in The Jackrabbit series."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Clara, Seb, engineers, Home, Book 5, The Proliferation, Starling, Jackrabbit, science fiction character, Tony Marks"/>
+<title>Clara &amp; Seb - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Clara &amp; Seb</h1>
+<p>Engineers &mdash; Home</p>
+</div>
+</section>
+<section class="character-profile">
+<div class="container">
+<div class="character-profile-container">
+<div class="character-portrait">
+<img alt="Clara &amp; Seb" src="./images/clara_and_seb.jpg"/>
+</div>
+<div class="character-details">
+<h2>Clara &amp; Seb</h2>
+<p class="role">Supporting Characters (Book 5)</p>
+<div class="character-section">
+<h3>Biography</h3>
+<p>Clara and Seb are the youngest engineers aboard Home — both born in zero gravity, both carrying the distinctive physiology of their environment, and both possessed of a technical aptitude that belies their limited resources. Clara is in her mid-twenties, methodical and precise, her spindly fingers moving across interfaces as though the technology were an extension of herself. Seb is slightly younger, enthusiastic and occasionally impulsive, with a tendency to become so absorbed in a problem that he loses track of time entirely.</p>
+<p>Together, they are responsible for the most significant engineering achievement in the resistance's history: bringing the pre-Purge manufacturing device to operational status and using it to produce functioning Starling devices. The path to that achievement was characterised by setbacks that would have defeated less determined engineers — including a fire caused by an underrated power cable that singed Seb's eyebrows and hair, and an interface so incomprehensible that only Aggie's intervention made it navigable.</p>
+<p>Their complementary skills proved essential throughout. Clara's methodical approach ensured that each step was documented and verified. Seb's willingness to experiment — to try the hammer, then the cutting disc, then the torch, then the plasma cutter against the impossibly dense Island Ore — demonstrated the persistence required when working with materials that defied every tool at their disposal.</p>
+<p>When the first Starling device was completed and activated without incident — no shockwave, no drama, just a steady hum and clean power output — Clara's response was to begin logging component cycle times. Seb's was to ask when they could start the next one. Both reactions were entirely in character.</p>
+</div>
+<div class="character-section">
+<h3>Personality Traits</h3>
+<div class="character-traits">
+<span class="trait">Methodical (Clara)</span>
+<span class="trait">Precise (Clara)</span>
+<span class="trait">Enthusiastic (Seb)</span>
+<span class="trait">Persistent (Seb)</span>
+<span class="trait">Resourceful (Both)</span>
+<span class="trait">Dedicated (Both)</span>
+</div>
+</div>
+<div class="character-section">
+<h3>Appearances</h3>
+<ul class="appearances">
+<li><strong>The Proliferation (Book 5)</strong> — Home's engineering team who bring the manufacturing device online, recover data from the splinter group's dead computer, and produce the Starling devices that begin undermining QuantumGrid's energy monopoly.</li>
+</ul>
+</div>
+<div class="character-section">
+<h3>Key Relationships</h3>
+<div class="relationships">
+<div class="relationship">
+<h4>Each Other</h4>
+<p>Clara and Seb work with the easy synchronisation of people who have spent their lives solving problems together. Clara's patience tempers Seb's enthusiasm; his willingness to try unconventional approaches complements her systematic rigour.</p>
+</div>
+<div class="relationship">
+<h4><a href="character2.html">Aggie</a></h4>
+<p>Their relationship with Aggie evolves from tentative cooperation to genuine collaboration. Clara's initial wariness gives way to respect when Aggie navigates the manufacturing device's interface in seconds. Seb's admiration is more immediate — and more openly expressed.</p>
+</div>
+<div class="relationship">
+<h4><a href="character38.html">Heinz</a></h4>
+<p>Heinz supports and oversees their engineering work with quiet pride, trusting their judgment in the workshop whilst remaining available for the decisions that extend beyond pure technical concerns.</p>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/characters.html
+++ b/characters.html
@@ -52,7 +52,7 @@
         <section class="page-header">
             <div class="container">
                  <h1>Character Biographies</h1>
-                <p>Meet the fascinating characters from The Jackrabbit Series, including those from "Stolen Freedom" (Book 1), "Wings of Freedom" (Book 2), "The Jackrabbit Emerges" (Book 3), and "Coming of Age" (Book 4).</p>
+                <p>Meet the fascinating characters from The Jackrabbit Series, including those from "Stolen Freedom" (Book 1), "Wings of Freedom" (Book 2), "The Jackrabbit Emerges" (Book 3), "Coming of Age" (Book 4), and "The Proliferation" (Book 5).</p>
             </div>
         </section>
 
@@ -467,6 +467,67 @@
                             <p class="character-role">Supporting Character (Book 4)</p>
                             <p class="character-description">Jack's direct superior at Aletheion who guides his advancement through the courier ranks, recognizing his exceptional abilities and promoting him with unprecedented speed.</p>
                             <a href="character34.html" class="read-more">Full Biography</a>
+                        </div>
+                    </div>
+
+                    <!-- New characters from Book 5 -->
+                    <div class="character-card">
+                        <div class="character-image">
+                            <img src="./images/kevin.jpg" alt="Kevin Farage">
+                        </div>
+                        <div class="character-info">
+                            <h3>Kevin Farage</h3>
+                            <p class="character-role">Antagonist (Book 5)</p>
+                            <p class="character-description">A bitter maintenance worker whose rage against corporate injustice transforms into violent extremism under the influence of a psychotic delusion.</p>
+                            <a href="character35.html" class="read-more">Full Biography</a>
+                        </div>
+                    </div>
+
+                    <div class="character-card">
+                        <div class="character-image">
+                            <img src="./images/andy.jpg" alt="Andy">
+                        </div>
+                        <div class="character-info">
+                            <h3>Andy</h3>
+                            <p class="character-role">Supporting Character (Book 5)</p>
+                            <p class="character-description">The patient, pragmatic leader of the zero-gravity resistance aboard Home, carrying six generations of inherited purpose.</p>
+                            <a href="character36.html" class="read-more">Full Biography</a>
+                        </div>
+                    </div>
+
+                    <div class="character-card">
+                        <div class="character-image">
+                            <img src="./images/avery.jpg" alt="Avery">
+                        </div>
+                        <div class="character-info">
+                            <h3>Avery</h3>
+                            <p class="character-role">Supporting Character (Book 5)</p>
+                            <p class="character-description">The youngest member of Home's original community, whose irrepressible enthusiasm and quiet competence make him the heart of the ship.</p>
+                            <a href="character39.html" class="read-more">Full Biography</a>
+                        </div>
+                    </div>
+
+                    <div class="character-card">
+                        <div class="character-image">
+                            <img src="./images/kathy.jpg" alt="Kathy">
+                        </div>
+                        <div class="character-info">
+                            <h3>Kathy</h3>
+                            <p class="character-role">Supporting Character (Book 5)</p>
+                            <p class="character-description">A resistance survivor from a dying outpost who discovers her purpose as the human face of an audacious rescue operation.</p>
+                            <a href="character40.html" class="read-more">Full Biography</a>
+                        </div>
+                    </div>
+
+                    <div class="character-card">
+                        <div class="character-image">
+                            <img src="./images/clara_and_seb.jpg" alt="Clara &amp; Seb">
+                        </div>
+                        <div class="character-info">
+                            <h3>Clara &amp; Seb</h3>
+                            <p class="character-role">Supporting Characters (Book 5)</p>
+                            <p class="character-description">Home's young engineering duo whose technical ingenuity and quiet determination bring the Starling device from blueprint to reality.</p>
+                            <a href="character41.html" class="read-more">Full Biography</a>
                         </div>
                     </div>
                 </div>

--- a/characters.html
+++ b/characters.html
@@ -497,6 +497,30 @@
 
                     <div class="character-card">
                         <div class="character-image">
+                            <img src="./images/pavan.jpg" alt="Pavan">
+                        </div>
+                        <div class="character-info">
+                            <h3>Pavan</h3>
+                            <p class="character-role">Supporting Character (Book 5)</p>
+                            <p class="character-description">A sharp-minded resistance leader whose tactical thinking and scientific curiosity complement Andy's steady pragmatism.</p>
+                            <a href="character37.html" class="read-more">Full Biography</a>
+                        </div>
+                    </div>
+
+                    <div class="character-card">
+                        <div class="character-image">
+                            <img src="./images/heinz.jpg" alt="Heinz">
+                        </div>
+                        <div class="character-info">
+                            <h3>Heinz</h3>
+                            <p class="character-role">Supporting Character (Book 5)</p>
+                            <p class="character-description">The engineering-minded resistance leader whose practical concerns ground the community's ambitions in physical reality.</p>
+                            <a href="character38.html" class="read-more">Full Biography</a>
+                        </div>
+                    </div>
+
+                    <div class="character-card">
+                        <div class="character-image">
                             <img src="./images/avery.jpg" alt="Avery">
                         </div>
                         <div class="character-info">


### PR DESCRIPTION
## Summary

- Adds seven new character bio pages for The Proliferation (Book 5): Kevin Farage, Andy, Pavan, Heinz, Avery, Kathy, and Clara & Seb
- Extends `characters.html` with five new character cards (one per provided image) and updates the page header to reference Book 5
- All new pages follow the established site template with full biography, personality traits, appearances, and key relationships sections with internal cross-links

## Notes

Pavan (character37) and Heinz (character38) have full bio pages and are fully cross-linked through key relationships on Andy's page and each other's pages. They do not have dedicated cards on the characters index as no separate images were provided for them — `andy.jpg` is used as a shared portrait placeholder. If you have images for Pavan and Heinz, I can add their cards and swap the portraits in a follow-up.

## Test plan

- [ ] Verify all five new character cards appear correctly at the bottom of `characters.html`
- [ ] Confirm "Full Biography" links on each card resolve to the correct page
- [ ] Check that internal Key Relationships links between the new pages (and back to existing characters such as Lucy Reeves and Aggie) work correctly
- [ ] Confirm Pavan and Heinz are reachable via the Key Relationships links on Andy's page

https://claude.ai/code/session_01SCUNZr6HQDauFosV5Vc3dk