### PR TITLE
Add Just Burke companion short story to the site

### DIFF
--- a/books.html
+++ b/books.html
@@ -343,6 +343,48 @@
                 </div>
             </div>
         </section>
+
+        <section class="books-overview companion-stories">
+            <div class="container">
+                <h2 class="character-group-heading">Companion Stories</h2>
+                <p class="comp-authors">Standalone short fiction set in the Jackrabbit universe. New readers can use these as an entry point; existing readers will find familiar names in unfamiliar light.</p>
+                <div class="books-list">
+                    <div class="book-item">
+                        <div class="book-cover">
+                            <img src="./images/just_burke_front_cover.jpg" alt="Just Burke cover">
+                        </div>
+                        <div class="book-details">
+                            <h2>Just Burke</h2>
+                            <p class="book-subtitle">A Companion Short Story &middot; ~50 pages</p>
+                            <p class="book-status">Status: eBook published &middot; Paperback forthcoming</p>
+                            <div class="book-description">
+                                <p>Thirty-one years before Jack Abbott walks into his workshop, Burke is a final-year student named Quentin &mdash; brilliant, isolated, and too tall for the chairs he keeps trying to sit in. He has chosen the hardest project on the list: a problem the field has spent a century failing to solve. What he doesn't yet understand is what kind of company OmniFab really is &mdash; and what happens to a young man who, in good faith, hands over the most important work he has ever done.</p>
+                                <p><em>Just Burke</em> is a standalone companion to the Jackrabbit series. Newcomers can read it as an introduction to the world; existing readers will recognise the man Jack would one day come to trust.</p>
+                            </div>
+                            <div class="book-features">
+                                <div class="feature">
+                                    <h3>Featured Character</h3>
+                                    <ul>
+                                        <li><a href="character11.html">Burke</a> (as a young man)</li>
+                                    </ul>
+                                </div>
+                                <div class="feature">
+                                    <h3>Key Themes</h3>
+                                    <ul>
+                                        <li>Ambition and Isolation</li>
+                                        <li>Corporate Betrayal</li>
+                                        <li>What Intelligence Cannot Save</li>
+                                        <li>The Long Road to Horizon Outpost</li>
+                                    </ul>
+                                </div>
+                            </div>
+                            <a href="just_burke.html" class="btn btn-primary">Read More</a>
+                            <a href="https://www.amazon.co.uk/dp/B0GZ2ZT83V" class="btn btn-primary" target="_blank">Get The eBook</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer>

--- a/character11.html
+++ b/character11.html
@@ -71,6 +71,7 @@
 <div class="character-section">
 <h3>Appearances</h3>
 <ul class="appearances">
+<li><strong><a href="just_burke.html">Just Burke</a></strong> (companion short story) - Set thirty-one years before <em>Stolen Freedom</em>, this standalone short tells how a brilliant final-year student named Quentin became the man who would one day take a chance on a strange boy named Jack. The story of what was taken from him &mdash; and what was left when it was gone.</li>
 <li><strong>Wings of Freedom</strong> - Burke first appears when Ozzy introduces Jack to him to refurbish and sell the stolen power pack. Later, he provides Jack with illegal quantum-locked communication devices that allow him to maintain secure contact with Aggie.</li>
 </ul>
 </div>

--- a/just_burke.html
+++ b/just_burke.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/>
+<meta name="description" content="Just Burke - a standalone companion short story to the Jackrabbit series. Thirty-one years before Jack Abbott walks into his workshop, Burke is a brilliant student named Quentin, about to learn what happens when good faith meets a corporation like OmniFab."/>
+<meta name="author" content="Tony Marks"/>
+<meta name="keywords" content="Just Burke, Jackrabbit, Tony Marks, short story, companion, OmniFab, Burke origin, science fiction"/>
+<!-- Open Graph Meta Tags -->
+<meta property="og:title" content="Just Burke - A Companion Story to The Jackrabbit Series"/>
+<meta property="og:description" content="Thirty-one years before Jack Abbott walks into his workshop, Burke is a brilliant student named Quentin. A standalone companion short story to the Jackrabbit series."/>
+<meta property="og:image" content="https://www.jackrabbit-series.com/images/just_burke_front_cover.jpg"/>
+<meta property="og:url" content="https://www.jackrabbit-series.com/just_burke.html"/>
+<meta property="og:type" content="book"/>
+<meta property="og:site_name" content="The Jackrabbit Series"/>
+<!-- Twitter Card Meta Tags -->
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="Just Burke - A Companion Story to The Jackrabbit Series"/>
+<meta name="twitter:description" content="Thirty-one years before Jack Abbott walks into his workshop, Burke is a brilliant student named Quentin. A standalone companion short story to the Jackrabbit series."/>
+<meta name="twitter:image" content="https://www.jackrabbit-series.com/images/just_burke_front_cover.jpg"/>
+<title>Just Burke - The Jackrabbit Series</title>
+<link rel="icon" href="/favicon.ico"/>
+<link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png"/>
+<link rel="apple-touch-icon" href="/apple-touch-icon.png"/>
+<link href="css/styles.css" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&amp;family=Merriweather:wght@300;400;700&amp;display=swap" rel="stylesheet"/>
+<!-- Structured Data -->
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Book",
+    "name": "Just Burke",
+    "alternateName": "Just Burke - A Companion Story to The Jackrabbit Series",
+    "author": {
+        "@type": "Person",
+        "name": "Tony Marks",
+        "url": "https://www.jackrabbit-series.com/contact.html",
+        "sameAs": [
+            "https://www.amazon.co.uk/stores/Tony-Marks/author/B0FVBF5PVQ",
+            "https://www.goodreads.com/author/show/58183421.Tony_Marks"
+        ]
+    },
+    "url": "https://www.jackrabbit-series.com/just_burke.html",
+    "image": "https://www.jackrabbit-series.com/images/just_burke_front_cover.jpg",
+    "description": "A standalone companion short story to the Jackrabbit series. Thirty-one years before Jack Abbott walks into his workshop, Burke is a final-year student named Quentin - brilliant, isolated, and about to discover what kind of company OmniFab really is.",
+    "genre": ["Science Fiction", "Short Fiction", "Dystopian Fiction"],
+    "inLanguage": "en",
+    "isPartOf": {
+        "@type": "BookSeries",
+        "name": "The Jackrabbit",
+        "url": "https://www.jackrabbit-series.com/"
+    },
+    "bookFormat": "EBook",
+    "keywords": "Burke origin, OmniFab, companion story, corporate betrayal, Jackrabbit prequel"
+}
+</script>
+</head>
+<body>
+<a href="#main-content" class="skip-link">Skip to main content</a>
+<header>
+<nav class="navbar" aria-label="Primary navigation">
+<div class="logo">
+<a href="index.html">The Jackrabbit</a>
+</div>
+<ul class="nav-links">
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+<div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+<div class="line1"></div>
+<div class="line2"></div>
+<div class="line3"></div>
+</div>
+</nav>
+</header>
+<main id="main-content">
+<section class="page-header">
+<div class="container">
+<h1>Just Burke</h1>
+<p>A Companion Story to The Jackrabbit Series</p>
+</div>
+</section>
+<section class="book-full">
+<div class="container">
+<div class="book-full-container">
+<div class="book-full-cover">
+<img src="./images/just_burke_front_cover.jpg" alt="Just Burke cover">
+</div>
+<div class="book-full-details">
+<h2>Just Burke</h2>
+<p class="book-subtitle">A Companion Short Story to The Jackrabbit Series</p>
+<p class="book-status">Status: eBook published &middot; Paperback forthcoming</p>
+<div class="purchase-ctas">
+<a href="https://www.amazon.co.uk/dp/B0GZ2ZT83V" class="btn btn-primary" target="_blank">Get the eBook</a>
+</div>
+<div class="book-section">
+<h3>Synopsis</h3>
+<p>Thirty-one years before Jack Abbott walks into his workshop, Burke is a final-year student named Quentin &mdash; brilliant, isolated, and too tall for the chairs he keeps trying to sit in.</p>
+<p>He has ambitions. A place at OmniFab's Research and Development arm, perhaps &mdash; the kind of career that justifies the loneliness of being the cleverest person in most rooms. To get there, he has chosen the hardest project on the list: a problem the field has spent a century failing to solve.</p>
+<p>What he doesn't yet understand is what kind of company OmniFab really is. What kind of system he is preparing to enter. And what happens to a young man who, in good faith, hands over the most important work he has ever done.</p>
+<p>The journey from that betrayal to a small workshop on Horizon Outpost is shorter than it ought to be &mdash; and longer than he could have imagined.</p>
+<p><em>Just Burke</em> is a standalone companion to the Jackrabbit series. A story about being the smartest person in the room, and discovering that intelligence isn't enough. About what gets stripped away, and what is left when it's gone.</p>
+</div>
+<div class="book-section">
+<h3>Where to Start</h3>
+<p>Newcomers can read <em>Just Burke</em> as an introduction to the world of the Jackrabbit series &mdash; a self-contained story that needs no prior reading. Existing readers will recognise the man Jack would one day come to trust.</p>
+</div>
+<div class="book-section">
+<h3>At a Glance</h3>
+<ul>
+<li><strong>Format:</strong> Short story (approx. 50 pages)</li>
+<li><strong>Place in the timeline:</strong> Thirty-one years before <a href="book1.html">Stolen Freedom</a></li>
+<li><strong>Reading order:</strong> Standalone &mdash; can be read before, after, or alongside the main series</li>
+<li><strong>Featured character:</strong> <a href="character11.html">Burke</a>, as a young man</li>
+</ul>
+</div>
+<div class="book-section">
+<h3>Explore the Universe</h3>
+<ul>
+<li><a href="character11.html">Burke</a> &mdash; the engineer Jack will meet decades later in <a href="book2.html">Wings of Freedom</a>.</li>
+<li><a href="encyclopaedia/Consortium.html">The Consortium</a> &mdash; the corporate bloc that produces companies like OmniFab.</li>
+<li><a href="encyclopaedia/Governance.html">Governance</a> &mdash; how corporate authority is exercised, and how it absorbs the work of those who serve it.</li>
+<li><a href="encyclopaedia/AGI.html">Artificial General Intelligence</a> &mdash; the forbidden technology whose suppression shapes every career, including Quentin's.</li>
+</ul>
+</div>
+<div class="purchase-ctas">
+<a href="https://www.amazon.co.uk/dp/B0GZ2ZT83V" class="btn btn-primary" target="_blank">Get the eBook</a>
+</div>
+</div>
+</div>
+</div>
+</section>
+</main>
+<footer>
+<div class="container">
+<div class="footer-content">
+<div class="footer-logo">
+<h3>The Jackrabbit</h3>
+<p>A science fiction series</p>
+</div>
+<div class="footer-links" role="navigation" aria-label="Footer navigation">
+<ul>
+<li><a href="index.html">Home</a></li>
+<li><a href="books.html">Books</a></li>
+<li><a href="characters.html">Characters</a></li>
+<li><a href="encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+<li><a href="contact.html">Contact</a></li>
+</ul>
+</div>
+</div>
+<div class="copyright">
+<p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+</div>
+</div>
+</footer>
+<script src="js/script.js"></script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -41,6 +41,13 @@
     <priority>0.8</priority>
   </url>
 
+  <!-- Companion Short Story -->
+  <url>
+    <loc>https://www.jackrabbit-series.com/just_burke.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
   <!-- Book 1 Prologue -->
   <url>
     <loc>https://www.jackrabbit-series.com/Book_1_Prologue.html</loc>


### PR DESCRIPTION
Adds a dedicated page for the new standalone short story, a Companion Stories section on the books index, an appearance entry on Burke's character page linking back to the new page, and a sitemap entry.

The main 5-book BookSeries schema is left intact - Just Burke is modelled as a standalone Book that isPartOf the series, rather than a sixth instalment, to keep the saga's reading order unambiguous.