### PR TITLE
Reflect Just Burke paperback availability in SEO and bottom CTA

### DIFF
--- a/just_burke.html
+++ b/just_burke.html
@@ -53,7 +53,20 @@
         "name": "The Jackrabbit",
         "url": "https://www.jackrabbit-series.com/"
     },
-    "bookFormat": "EBook",
+    "workExample": [
+        {
+            "@type": "Book",
+            "bookFormat": "https://schema.org/Paperback",
+            "url": "https://amzn.eu/d/0fhuIM8x",
+            "inLanguage": "en"
+        },
+        {
+            "@type": "Book",
+            "bookFormat": "https://schema.org/EBook",
+            "url": "https://www.amazon.co.uk/dp/B0GZ2ZT83V",
+            "inLanguage": "en"
+        }
+    ],
     "keywords": "Burke origin, OmniFab, companion story, corporate betrayal, Jackrabbit prequel"
 }
 </script>
@@ -134,6 +147,7 @@
 </div>
 <div class="purchase-ctas">
 <a href="https://www.amazon.co.uk/dp/B0GZ2ZT83V" class="btn btn-primary" target="_blank">Get the eBook</a>
+<a href="https://amzn.eu/d/0fhuIM8x" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Replace single bookFormat:EBook in the JSON-LD with a workExample array covering both Paperback and EBook editions so rich-result crawlers see both formats. Also add the missing paperback link to the duplicate purchase-ctas block at the bottom of the page.