### PR TITLE
Add in-universe 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, follow">
+    <meta name="description" content="The page you requested could not be located. Return to the authorised sections of The Jackrabbit Series.">
+    <meta name="author" content="Tony Marks">
+    <title>Record Not Found - The Jackrabbit Series</title>
+    <link rel="icon" href="/favicon.ico">
+    <link rel="icon" href="/favicon-32x32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="stylesheet" href="/css/styles.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Merriweather:wght@300;400;700&display=swap" rel="stylesheet">
+    <style>
+        .aetherlink-terminal {
+            max-width: 760px;
+            margin: 3rem auto;
+            padding: 2.5rem 2.5rem 2rem;
+            background-color: #0f1620;
+            color: #cfe3ff;
+            border: 1px solid #2a3a52;
+            border-radius: 4px;
+            font-family: var(--font-body);
+            box-shadow: 0 10px 30px rgba(0,0,0,0.25);
+        }
+        .aetherlink-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 1px solid #2a3a52;
+            padding-bottom: 0.75rem;
+            margin-bottom: 1.5rem;
+            font-family: var(--font-heading);
+            font-size: 0.85rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #7fb3ff;
+        }
+        .aetherlink-status {
+            color: #ff8a8a;
+        }
+        .aetherlink-terminal h1 {
+            font-size: 2.2rem;
+            color: #ffffff;
+            margin-bottom: 0.5rem;
+        }
+        .aetherlink-terminal .query-line {
+            font-family: var(--font-heading);
+            font-size: 0.9rem;
+            color: #7fb3ff;
+            margin-bottom: 1.5rem;
+            letter-spacing: 0.04em;
+        }
+        .aetherlink-terminal p {
+            margin-bottom: 1rem;
+            color: #cfe3ff;
+        }
+        .aetherlink-terminal p.notice {
+            font-style: italic;
+            color: #9fb8d9;
+        }
+        .aetherlink-footer {
+            margin-top: 1.5rem;
+            padding-top: 1rem;
+            border-top: 1px solid #2a3a52;
+            font-family: var(--font-heading);
+            font-size: 0.75rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: #5a7aa3;
+            text-align: center;
+        }
+        .authorised-content {
+            max-width: 760px;
+            margin: 0 auto 4rem;
+            padding: 0 1rem;
+            text-align: center;
+        }
+        .authorised-content h2 {
+            font-size: 1.4rem;
+            margin-bottom: 1rem;
+            text-align: center;
+        }
+        .authorised-content ul {
+            list-style: none;
+            padding: 0;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 1rem;
+        }
+        .authorised-content li a {
+            display: inline-block;
+            padding: 0.6rem 1.2rem;
+            background-color: var(--primary-color);
+            color: var(--light-text);
+            text-decoration: none;
+            border-radius: 4px;
+            font-family: var(--font-heading);
+            font-weight: 600;
+            transition: var(--transition);
+        }
+        .authorised-content li a:hover {
+            background-color: var(--accent-color);
+        }
+    </style>
+</head>
+<body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+    <header>
+        <nav class="navbar" aria-label="Primary navigation">
+            <div class="logo">
+                <a href="/index.html">The Jackrabbit</a>
+            </div>
+            <ul class="nav-links">
+                <li><a href="/index.html">Home</a></li>
+                <li><a href="/books.html">Books</a></li>
+                <li><a href="/characters.html">Characters</a></li>
+                <li><a href="/encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+                <li><a href="/contact.html">Contact</a></li>
+            </ul>
+            <div class="burger" role="button" aria-label="Toggle navigation menu" aria-expanded="false" tabindex="0">
+                <div class="line1"></div>
+                <div class="line2"></div>
+                <div class="line3"></div>
+            </div>
+        </nav>
+    </header>
+
+    <main id="main-content">
+        <section class="aetherlink-terminal" aria-labelledby="aetherlink-heading">
+            <div class="aetherlink-header">
+                <span>AetherLink Public Records Interface</span>
+                <span class="aetherlink-status">Query 404 &middot; No Record</span>
+            </div>
+            <h1 id="aetherlink-heading">404</h1>
+
+            <p>AetherLink has no record of this resource. Therefore, it has never existed.</p>
+
+            <p>Please return to approved content.</p>
+
+            <p class="notice">This query has been logged against your identity. Repeated attempts to access non-existent resources will result in connectivity review.</p>
+
+            <div class="aetherlink-footer">
+                Transmission ID 0x404-NULL &middot; Records Compliance Division &middot; AetherLink
+            </div>
+        </section>
+
+        <section class="authorised-content" aria-labelledby="authorised-heading">
+            <h2 id="authorised-heading">Approved Content</h2>
+            <p style="margin-bottom: 1.5rem;">The following sections of the archive remain available for your review:</p>
+            <ul>
+                <li><a href="/index.html">Home</a></li>
+                <li><a href="/books.html">Books</a></li>
+                <li><a href="/characters.html">Characters</a></li>
+                <li><a href="/encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+                <li><a href="/contact.html">Contact</a></li>
+            </ul>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-logo">
+                    <h3>The Jackrabbit</h3>
+                    <p>A science fiction series</p>
+                </div>
+                <div class="footer-links" role="navigation" aria-label="Footer navigation">
+                    <ul>
+                        <li><a href="/index.html">Home</a></li>
+                        <li><a href="/books.html">Books</a></li>
+                        <li><a href="/characters.html">Characters</a></li>
+                        <li><a href="/encyclopaedia/encyclopaedia.html">Encyclopaedia</a></li>
+                        <li><a href="/contact.html">Contact</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="copyright">
+                <p>&copy; 2025 The Jackrabbit Series. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+    <script src="/js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Adds a custom 404.html served automatically by GitHub Pages on any unmatched path. Styled to match the rest of the site (shared CSS, nav, footer) with an in-universe message from AetherLink — the consortium's records-and-surveillance megacorp — informing the visitor that the requested record does not exist and that their query has been logged. Recovery links to Home, Books, Characters, Encyclopaedia and Contact keep the page useful as a navigational dead-end. noindex,follow on the robots meta prevents Google from indexing the 404 itself while still allowing it to follow the recovery links.