### PR TITLE
Add top padding to 404 page main element

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,6 +15,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Merriweather:wght@300;400;700&display=swap" rel="stylesheet">
     <style>
+        main {
+            padding-top: 2rem;
+        }
         .aetherlink-terminal {
             max-width: 760px;
             margin: 3rem auto;


### PR DESCRIPTION
The AetherLink terminal box's 3rem top margin was collapsing into the <main> element (which had no top padding or border to stop it), leaving no visible gap between the navbar and the box. Adding padding-top to main breaks the collapse and lets the margin land where intended.