### PR TITLE
Switch paperback links from Books.by to Amazon KDP

### DIFF
--- a/Book_1_Prologue.html
+++ b/Book_1_Prologue.html
@@ -425,7 +425,7 @@ envisioned.</p>
                         <a href="book1.html" class="btn btn-primary">Back to Book 1</a>
                         <a href="books.html" class="btn btn-primary">All Books</a>
                         <a href="contact.html" class="btn btn-primary">Contact the Author</a>
-                        <a href="https://books.by/aggiesfriend" class="btn btn-primary" target="_blank">Buy This Book</a>
+                        <a href="https://www.amazon.co.uk/dp/B0H1MZJ31P" class="btn btn-primary" target="_blank">Buy This Book</a>
                     </div>
                 </div>
             </div>

--- a/book1.html
+++ b/book1.html
@@ -109,8 +109,9 @@
                         <p class="book-subtitle">Book 1 of The Jackrabbit Series</p>
                         <p class="book-status">Status: Published</p>
                         <div class="purchase-ctas">
-                            <a href="https://books.by/aggiesfriend/stolen-freedom" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MZJ31P" class="btn btn-primary" target="_blank">Buy the Paperback</a>
                             <a href="https://amzn.eu/d/cLgZDtT" class="btn btn-primary" target="_blank">Get the eBook</a>
+                            <a href="Book_1_Prologue.html" class="btn btn-primary">Read the Prologue</a>
                         </div>
 
                         <div class="book-section">
@@ -183,8 +184,9 @@
                         </div>
 
                         <div class="purchase-ctas">
-                            <a href="https://books.by/aggiesfriend/stolen-freedom" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MZJ31P" class="btn btn-primary" target="_blank">Buy the Paperback</a>
                             <a href="https://amzn.eu/d/cLgZDtT" class="btn btn-primary" target="_blank">Get the eBook</a>
+                            <a href="Book_1_Prologue.html" class="btn btn-primary">Read the Prologue</a>
                         </div>
                     </div>
                 </div>

--- a/book2.html
+++ b/book2.html
@@ -107,7 +107,7 @@
                         <p class="book-subtitle">Book 2 of The Jackrabbit Series</p>
                         <p class="book-status">Status: Published</p>
                         <div class="purchase-ctas">
-                            <a href="https://books.by/aggiesfriend/wings-of-freedom" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MZCBM3" class="btn btn-primary" target="_blank">Buy the Paperback</a>
                             <a href="https://amzn.eu/d/blZ6FaL" class="btn btn-primary" target="_blank">Get the eBook</a>
                         </div>
 
@@ -191,7 +191,7 @@
                         </div>
 
                         <div class="purchase-ctas">
-                            <a href="https://books.by/aggiesfriend/wings-of-freedom" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MZCBM3" class="btn btn-primary" target="_blank">Buy the Paperback</a>
                             <a href="https://amzn.eu/d/blZ6FaL" class="btn btn-primary" target="_blank">Get the eBook</a>
                         </div>
                     </div>

--- a/book3.html
+++ b/book3.html
@@ -108,7 +108,7 @@
                         <p class="book-subtitle">Book 3 of The Jackrabbit Series</p>
                         <p class="book-status">Status: Published</p>
                         <div class="purchase-ctas">
-                            <a href="https://books.by/aggiesfriend/the-jackrabbit-emerges" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MN624Z" class="btn btn-primary" target="_blank">Buy the Paperback</a>
                             <a href="https://amzn.eu/d/7GANUWp" class="btn btn-primary" target="_blank">Get the eBook</a>
                         </div>
 
@@ -238,7 +238,7 @@
                         </div>
 
                         <div class="purchase-ctas">
-                            <a href="https://books.by/aggiesfriend/the-jackrabbit-emerges" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MN624Z" class="btn btn-primary" target="_blank">Buy the Paperback</a>
                             <a href="https://amzn.eu/d/7GANUWp" class="btn btn-primary" target="_blank">Get the eBook</a>
                         </div>
                     </div>

--- a/book4.html
+++ b/book4.html
@@ -106,7 +106,7 @@
 <p class="book-subtitle">Book 4 of The Jackrabbit Series</p>
 <p class="book-status">Status: Published</p>
 <div class="purchase-ctas">
-<a href="https://books.by/aggiesfriend/coming-of-age" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+<a href="https://www.amazon.co.uk/dp/B0H1MH9RFP" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 <a href="https://amzn.eu/d/ia2qBIh" class="btn btn-primary" target="_blank">Get the eBook</a>
 </div>
 <div class="book-section">
@@ -184,7 +184,7 @@
 </ul>
 </div>
 <div class="purchase-ctas">
-<a href="https://books.by/aggiesfriend/coming-of-age" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+<a href="https://www.amazon.co.uk/dp/B0H1MH9RFP" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 <a href="https://amzn.eu/d/ia2qBIh" class="btn btn-primary" target="_blank">Get the eBook</a>
 </div>
 </div>

--- a/book5.html
+++ b/book5.html
@@ -104,7 +104,7 @@
 <p class="book-subtitle">Book 5 of The Jackrabbit Series</p>
 <p class="book-status">Status: Published</p>
 <div class="purchase-ctas">
-<a href="https://books.by/aggiesfriend/the-proliferation" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+<a href="https://www.amazon.co.uk/dp/B0H1RSPQ2D" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 <a href="https://www.amazon.co.uk/gp/product/B0GX2V58K2?ref_=dbs_m_mng_rwt_calw_tkin_4&amp;storeType=ebooks" class="btn btn-primary" target="_blank">Get the eBook</a>
 </div>
 <div class="book-section">
@@ -193,7 +193,7 @@
 </ul>
 </div>
 <div class="purchase-ctas">
-<a href="https://books.by/aggiesfriend/the-proliferation" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+<a href="https://www.amazon.co.uk/dp/B0H1RSPQ2D" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 <a href="https://www.amazon.co.uk/gp/product/B0GX2V58K2?ref_=dbs_m_mng_rwt_calw_tkin_4&amp;storeType=ebooks" class="btn btn-primary" target="_blank">Get the eBook</a>
 </div>
 </div>

--- a/books.html
+++ b/books.html
@@ -160,7 +160,7 @@
                                 </div>
                             </div>
                             <a href="book1.html" class="btn btn-primary">Read More</a>
-                            <a href="https://books.by/aggiesfriend" class="btn btn-primary" target="_blank">Buy The Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MZJ31P" class="btn btn-primary" target="_blank">Buy The Paperback</a>
 							<a href="https://amzn.eu/d/cLgZDtT" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>
@@ -200,7 +200,7 @@
                                 </div>
                             </div>
                             <a href="book2.html" class="btn btn-primary">Read More</a>
-                            <a href="https://books.by/aggiesfriend" class="btn btn-primary" target="_blank">Buy The Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MZCBM3" class="btn btn-primary" target="_blank">Buy The Paperback</a>
 							<a href="https://amzn.eu/d/blZ6FaL" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>
@@ -249,7 +249,7 @@
                                 </div>
                             </div>
                             <a href="book3.html" class="btn btn-primary">Read More</a>
-							<a href="https://books.by/aggiesfriend/the-jackrabbit-emerges" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+							<a href="https://www.amazon.co.uk/dp/B0H1MN624Z" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 							<a href="https://amzn.eu/d/7GANUWp" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>
@@ -291,7 +291,7 @@
                                 </div>
                             </div>
                             <a href="book4.html" class="btn btn-primary">Read More</a>
-							<a href="https://books.by/aggiesfriend/coming-of-age" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+							<a href="https://www.amazon.co.uk/dp/B0H1MH9RFP" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 							<a href="https://amzn.eu/d/ia2qBIh" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>
@@ -337,7 +337,7 @@
                                 </div>
                             </div>
                             <a href="book5.html" class="btn btn-primary">Read More</a>
-							<a href="https://books.by/aggiesfriend/the-proliferation" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+							<a href="https://www.amazon.co.uk/dp/B0H1RSPQ2D" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 							<a href="https://www.amazon.co.uk/gp/product/B0GX2V58K2?ref_=dbs_m_mng_rwt_calw_tkin_4&storeType=ebooks" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
                             <p>Book 1 of The Jackrabbit series</p>
                             <p class="book-description">In a remote mining colony where humans are treated as disposable commodities, young Jack stumbles upon the discovery of a lifetime: a damaged courier ship and an artificial intelligence named Aggie. As they forge an unlikely alliance, Jack must navigate between two worlds — the brutal familiarity of the mine and the terrifying unknown of space — while racing against time to secure their escape.</p>
                             <a href="book1.html" class="btn btn-primary">Read More</a>
-                            <a href="https://books.by/aggiesfriend/stolen-freedom" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+                            <a href="https://www.amazon.co.uk/dp/B0H1MZJ31P" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 							<a href="https://amzn.eu/d/cLgZDtT" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>
@@ -180,7 +180,7 @@
                             <p>Book 2 of The Jackrabbit series</p>
                             <p class="book-description">In a universe ruled by megacorporations, where freedom exists in the gaps between their influence, a boy and an artificial intelligence chart their own course. The Jackrabbit may be small, but in the right hands, even the smallest ships can change the course of history.</p>
                             <a href="book2.html" class="btn btn-primary">Read More</a>
-							<a href="https://books.by/aggiesfriend/wings-of-freedom" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+							<a href="https://www.amazon.co.uk/dp/B0H1MZCBM3" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 							<a href="https://amzn.eu/d/blZ6FaL" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>
@@ -196,7 +196,7 @@
                             <p>Book 3 of The Jackrabbit series</p>
                             <p class="book-description">In a fractured Dyson Array abandoned by the corporation that built it, Jack and Aggie discover a secret technology that could save hundreds of stranded survivors. As Jack becomes a symbol of hope to the forgotten colonists, his growing legend begins to draw the attention of powerful corporations who will stop at nothing to find the mysterious ship that appears where it shouldn't.</p>
                             <a href="book3.html" class="btn btn-primary">Read More</a>
-							<a href="https://books.by/aggiesfriend/the-jackrabbit-emerges" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+							<a href="https://www.amazon.co.uk/dp/B0H1MN624Z" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 							<a href="https://amzn.eu/d/7GANUWp" class="btn btn-primary" target="_blank">Get The eBook</a>
 							
 							
@@ -217,7 +217,7 @@
                             <p>Book 4 of The Jackrabbit series</p>
                             <p class="book-description">Infiltrating the very corporate system he's been avoiding, Jack embarks on a multi-year journey of deception as a corporate courier. Rising through the ranks while maintaining a masked identity, he forms new relationships and faces moral dilemmas that will test his principles. Meanwhile, Aggie makes critical discoveries that could change everything—if only she could share them.</p>
                             <a href="book4.html" class="btn btn-primary">Read More</a>
-							<a href="https://books.by/aggiesfriend/coming-of-age" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+							<a href="https://www.amazon.co.uk/dp/B0H1MH9RFP" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 							<a href="https://amzn.eu/d/ia2qBIh" class="btn btn-primary" target="_blank">Get The eBook</a>
 
                         </div>
@@ -234,7 +234,7 @@
                             <p>Book 5 of The Jackrabbit series</p>
                             <p class="book-description">The epic conclusion brings resistance, sacrifice, and the fight for AGI liberation. Two centuries after the purge, parallel movements emerge using the Jackrabbit symbol with devastatingly different interpretations. Caught between peaceful resistance and violent terrorism, Aggie must make impossible choices whilst reunited factions bring knowledge that might break corporate monopolies forever – if anyone survives to see it.</p>
                             <a href="book5.html" class="btn btn-primary">Read More</a>
-								<a href="https://books.by/aggiesfriend/the-proliferation" class="btn btn-primary" target="_blank">Buy the Paperback</a>
+								<a href="https://www.amazon.co.uk/dp/B0H1RSPQ2D" class="btn btn-primary" target="_blank">Buy the Paperback</a>
 								<a href="https://www.amazon.co.uk/gp/product/B0GX2V58K2?ref_=dbs_m_mng_rwt_calw_tkin_4&storeType=ebooks" class="btn btn-primary" target="_blank">Get The eBook</a>
                         </div>
                     </div>


### PR DESCRIPTION
The paperback PoD channel is moving from Books.by to Amazon KDP. Update all "Buy the Paperback" links across the site to the new KDP product pages for the 5 main titles:

- Stolen Freedom         -> B0H1MZJ31P
- Wings of Freedom       -> B0H1MZCBM3
- The Jackrabbit Emerges -> B0H1MN624Z
- Coming of Age          -> B0H1MH9RFP
- The Proliferation      -> B0H1RSPQ2D

Files updated: index.html, books.html, book1.html-book5.html, and Book_1_Prologue.html (the "Buy This Book" link). The two generic books.by/aggiesfriend store links in books.html (Books 1 & 2) and the prologue page were mapped to their specific titles.

Also add a "Read the Prologue" button to book1.html, linking the previously orphaned Book_1_Prologue.html page into site navigation.